### PR TITLE
fix: prevent Navbar re-animation on route change

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,6 @@ export const Navbar = () => {
     <div className="fixed top-0 left-0 right-0 z-50">
       <AnimatePresence mode="wait" initial={false}>
         <motion.nav
-          key={location.pathname}
           className={cn(
             "transition-all duration-300 ease-out will-change-transform",
             isScrolled 


### PR DESCRIPTION
- Remove key={location.pathname} from the motion.nav component.
- This key was causing the Navbar to unmount and remount with AnimatePresence on every route change.
- The Navbar should persist across page navigations without triggering full exit and enter animations.
- This change resolves unwanted flickering or animation glitches when switching routes.